### PR TITLE
Use new system-trace extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt": "^0.4.5",
     "jquery": "^2.1.4",
     "live-reload-testing": "^2.0.0",
-    "steal": "^0.11.0",
+    "steal": "git://github.com/stealjs/steal#trace",
     "steal-qunit": "^0.1.1",
     "testee": "^0.2.0"
   },

--- a/test/basics/dep.js
+++ b/test/basics/dep.js
@@ -1,0 +1,1 @@
+module.exports={};

--- a/test/basics/main.js
+++ b/test/basics/main.js
@@ -1,5 +1,6 @@
 var $ = require("jquery");
 var reload = require("live-reload");
+require("./dep");
 
 var span = $("<span class='main'>loaded</span>");
 $("#app").append(span);

--- a/test/test.js
+++ b/test/test.js
@@ -24,7 +24,23 @@ QUnit.test("reloads the module when the file changes", function(){
 
 	F(function(){
 		var address = "test/basics/main.js";
-		var content = "var $ = require('jquery');\nvar span = $('<span class=\"main\">loaded</span>');\n$('#app').append(span);";
+		var content = "var $ = req" + "uire('jquery');req" + "uire('./dep');\nvar span = $('<span class=\"main\">loaded</span>');\n$('#app').append(span);";
+
+		liveReloadTest.put(address, content).then(null, function(){
+			QUnit.ok(false, "Reload was not successful");
+			QUnit.start();
+		});
+	});
+
+	F(".main").size(2, "Reloaded so now there is a second span");
+});
+
+QUnit.test("reloads when a dependency reloads", function(){
+	F(".main").size(1, "There is one main span");
+
+	F(function(){
+		var address = "test/basics/dep.js";
+		var content = "module.exports={}";
 
 		liveReloadTest.put(address, content).then(null, function(){
 			QUnit.ok(false, "Reload was not successful");


### PR DESCRIPTION
This adds a new dependency on live-reload, system-trace. It takes over
the aspects of live-reload that was keeping a parentMap so that these
parts could be removed from our code base. Since this creates a new
dependency I'm going to bump this change up to 1.0
