### PR TITLE
Dispose orphaned modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ If you're using SystemJS install with NPM:
 npm install system-live-reload --save-dev
 ```
 
+live-reload requires the `system-trace` extension so install that as well:
+
+```shell
+npm install system-trace --save-dev
+```
+
 # Use
 
 ## StealJS
@@ -47,10 +53,11 @@ In your `steal.js` script tag you can specify a port, otherwise `8012` will be u
 
 ## SystemJS
 
-Using with SystemJS takes a little extra configuration.  Probably you want to do this in the script tag following your use of SystemJS:
+Using with SystemJS takes a little extra configuration. Probably you want to do this in the script tag following your use of SystemJS:
 
 ```html
 <script src="path/to/system.js"></script>
+<script src="node_modules/system-trace/trace.js"></script>
 <script>
   System.set("@loader", System.newModule({ default: System, __useDefault: true }));
   System.paths["live-reload"] = "node_modules/system-live-reload/live.js";
@@ -64,6 +71,8 @@ Using with SystemJS takes a little extra configuration.  Probably you want to do
 
 </script>
 ```
+
+Note that a script tag for [system-trace](https://github.com/stealjs/system-trace) is included as well, this is because live-reload depends on that extension.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/stealjs/live-reload.svg?branch=master)](https://travis-ci.org/stealjs/live-reload)
+
 # live-reload
 
 An extension for [SystemJS](https://github.com/systemjs/systemjs) and 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt": "^0.4.5",
     "jquery": "^2.1.4",
     "live-reload-testing": "^2.0.0",
-    "steal": "git://github.com/stealjs/steal#trace",
+    "steal": "^0.12.0-pre.0",
     "steal-qunit": "^0.1.1",
     "testee": "^0.2.0"
   },

--- a/test/orphan/index.html
+++ b/test/orphan/index.html
@@ -1,0 +1,15 @@
+<head><meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+<meta http-equiv="Pragma" content="no-cache" />
+<meta http-equiv="Expires" content="0" /></head>
+<body>
+<script>
+	steal = {
+		configDependencies: ["live-reload"],
+		paths: {
+			"live-reload": "live.js"
+		}
+	};
+</script>
+<script src="../../node_modules/steal/steal.js" main="test/orphan/main"></script>
+<div id="app"></div>
+</body>

--- a/test/orphan/main.js
+++ b/test/orphan/main.js
@@ -1,0 +1,1 @@
+require("./orphan");

--- a/test/orphan/orphan.js
+++ b/test/orphan/orphan.js
@@ -1,0 +1,8 @@
+var reload = require("live-reload");
+var $ = require("jquery");
+
+$("#app").append($("<div id='orphan'>im an orphan module</div>"));
+
+reload.dispose(function(){
+	$("#orphan").remove();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -50,3 +50,34 @@ QUnit.test("reloads when a dependency reloads", function(){
 
 	F(".main").size(2, "Reloaded so now there is a second span");
 });
+
+QUnit.module("orphan modules", {
+	setup: function(assert){
+		var done = assert.async();
+		F.open("//orphan/index.html", function(){
+			done();
+		});
+	},
+	teardown: function(assert){
+		var done = assert.async();
+		liveReloadTest.reset().then(function(){
+			done();
+		});
+	}
+});
+
+QUnit.test("get disposed during the reload process", function(){
+	F("#orphan").exists("The orphaned module is loaded");
+
+	F(function(){
+		var address = "test/orphan/main.js";
+		var content = "module.exports={};";
+
+		liveReloadTest.put(address, content).then(null, function(){
+			QUnit.ok(false, "Reload was not successful");
+			QUnit.start();
+		});
+	});
+
+	F("#orphan").missing("The orphaned module was torn down");
+});


### PR DESCRIPTION
This fixes a problem we were happened when an orphaned module (a module
        no longer parter of the dependency graph) was being left alive
in the client. The fix is to examine the reloading module's dependencies
before and after the reload cycle so that we can properly dispose the
orphans.
