### PR TITLE
Allows live-reload to be loaded in the server

### DIFF
--- a/live.js
+++ b/live.js
@@ -1,4 +1,5 @@
 var loader = require("@loader");
+var steal = require("@steal");
 
 // This is a map of listeners, those who have registered reload callbacks.
 loader._liveListeners = {};
@@ -226,7 +227,7 @@ function setup(){
 
 	var port = loader.liveReloadPort || 8012;
 
-	var host = window.document.location.host.replace(/:.*/, '');
+	var host = loader.liveReloadHost || window.document.location.host.replace(/:.*/, '');
 	var ws = new WebSocket("ws://" + host + ":" + port);
 
 	// Let the server know about the main module
@@ -241,9 +242,9 @@ function setup(){
 }
 
 
-var isBrowser = typeof window !== "undefined";
+var isBuildEnvironment = loader.isPlatform("build") || loader.isEnv("build");
 
-if(isBrowser) {
+if(!isBuildEnvironment) {
 	if(typeof steal !== "undefined") {
 		steal.done().then(setup);
 	} else {


### PR DESCRIPTION
This update allows for live-reload to be loaded on the server. It does
this by removing the browser restriction and making it so that the
`loader.liveReloadHost` option can be set in order to know what host to
use.
