### PR TITLE
Provide a flag on the loader to indicate that live-reload is running.

### DIFF
--- a/live.js
+++ b/live.js
@@ -3,6 +3,7 @@ var steal = require("@steal");
 
 // This is a map of listeners, those who have registered reload callbacks.
 loader._liveListeners = {};
+loader.liveReloadInstalled = true;
 
 // A simple emitter
 function E () {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "funcunit": "^3.0.0",
     "grunt": "^0.4.5",
     "jquery": "^2.1.4",
-    "live-reload-testing": "^2.0.0",
+    "live-reload-testing": "^3.0.1",
     "steal": "^0.12.0-pre.0",
     "steal-qunit": "^0.1.1",
     "testee": "^0.2.0"


### PR DESCRIPTION
This adds a flag `liveReloadInstalled` on the loader object so that
plugins can detect that live-reload is running.
