### PR TITLE
Retry a connection when unable to connect.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ reload.dispose(function(){
 
 You can specify which port to use for the WebSocket connection. By default `8012` will be used.
 
+#### liveReloadAttempts
+
+If live-reload is unable to connect to a server it can attempt to retry on a delay. **liveReloadAttempts** specifies the number of times to try connecting. By default **liveReloadAttempts** is 1, meaning no retries will occur.
+
+#### liveReloadRetryTimeout
+
+When live-reload retries to connect to a server, **liveReloadRetryTimeout** configures the timeout, in milliseconds, before a retry will occur.
+
 ## License
 
 MIT

--- a/test/retry/index.html
+++ b/test/retry/index.html
@@ -1,0 +1,37 @@
+<script>
+	window.QUnit = window.parent.QUnit;
+	window.removeMyself = window.parent.removeMyself;
+
+	var __count = 0;
+	var __WebSocket = window.WebSocket;
+	window.WebSocket = function(a, b){
+		var ws = new __WebSocket(a, b);
+
+		ws.addEventListener("close", function(){
+			__count++;
+			if(__count === 3) {
+				QUnit.ok(true, "Retried after a failure");
+				QUnit.start();
+				window.removeMyself();
+			} else if(__count > 3) {
+				QUnit.ok(false, "attempted too many times");
+			}
+		});
+
+		return ws;
+	};
+
+	steal = {
+		liveReloadAttempts: 3,
+
+		// Some port we aren't really using
+		liveReloadPort: 8112,
+
+		configDependencies: ["live-reload"],
+		paths: {
+			"live-reload": "live.js"
+		}
+	};
+</script>
+<script src="../../node_modules/steal/steal.js" main="test/retry/main"></script>
+<div id="app"></div>

--- a/test/retry/main.js
+++ b/test/retry/main.js
@@ -1,0 +1,5 @@
+var reload = require("live-reload");
+
+reload(function(){
+	console.log("Stuff reloaded");
+});

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,16 @@ var F = require("funcunit");
 
 F.attach(QUnit);
 
+var makeIframe = function(src){
+	var iframe = document.createElement("iframe");
+	window.removeMyself = function(){
+		delete window.removeMyself;
+		//document.body.removeChild(iframe);
+	};
+	document.body.appendChild(iframe);
+	iframe.src = src;
+};
+
 QUnit.module("basics", {
 	setup: function(assert){
 		var done = assert.async();
@@ -80,4 +90,10 @@ QUnit.test("get disposed during the reload process", function(){
 	});
 
 	F("#orphan").missing("The orphaned module was torn down");
+});
+
+QUnit.module("retries");
+
+QUnit.asyncTest("something", function(){
+	makeIframe("retry/index.html");
 });


### PR DESCRIPTION
When live-reload is unable to connect to a server, perhaps because the
server is not yet started we need to retry the connection after a
timeout. This change adds two new configurations for retries:
- liveReloadAttempts
- liveReloadRetryTimeout
