### PR TITLE
Only dispose orphans with 1 dependant module

### DIFF
--- a/live.js
+++ b/live.js
@@ -178,7 +178,7 @@ function bind(fn, ctx){
 
 function reload(moduleName) {
 	var e = loader._liveEmitter;
-	var currentDeps = loader.getDependencies(moduleName);
+	var currentDeps = loader.getDependencies(moduleName) || [];
 
 	// Call teardown to recursively delete all parents, then call `import` on the
 	// top-level parents.
@@ -210,13 +210,17 @@ function reload(moduleName) {
 }
 
 function removeOrphans(moduleName, oldDeps){
-	var deps = loader.getDependencies(moduleName);
+	var deps = loader.getDependencies(moduleName) || [];
 
 	var depName;
 	for(var i = 0, len = oldDeps.length; i < len; i++) {
 		depName = oldDeps[i];
 		if(!~deps.indexOf(depName)) {
-			disposeModule(depName, loader._liveEmitter);
+			var dependants = loader.getDependants(depName);
+			// Only teardown if this is the only dependant module.
+			if(dependants.length === 1) {
+				disposeModule(depName, loader._liveEmitter);
+			}
 		}
 	}
 }

--- a/test/orphan/other.html
+++ b/test/orphan/other.html
@@ -1,0 +1,15 @@
+<head><meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+<meta http-equiv="Pragma" content="no-cache" />
+<meta http-equiv="Expires" content="0" /></head>
+<body>
+<script>
+	steal = {
+		configDependencies: ["live-reload"],
+		paths: {
+			"live-reload": "live.js"
+		}
+	};
+</script>
+<script src="../../node_modules/steal/steal.js" main="test/orphan/other"></script>
+<div id="app"></div>
+</body>

--- a/test/orphan/other.js
+++ b/test/orphan/other.js
@@ -1,0 +1,10 @@
+require("./main");
+require("./orphan");
+
+var reload = require("live-reload");
+
+$("#app").append($("<div id='other'>im other</div>"));
+
+reload.dispose(function(){
+	$("#other").remove();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -92,6 +92,26 @@ QUnit.test("get disposed during the reload process", function(){
 	F("#orphan").missing("The orphaned module was torn down");
 });
 
+QUnit.test("are not orphans if they have another parent", function(){
+	F.open("//orphan/other.html");
+
+	F("#orphan").exists("The orphaned module is loaded");
+
+	F(function(){
+		var address = "test/orphan/other.js";
+		var content = "requ" + "ire('./main'); requ" +
+			"ire('live-reload');";
+
+		liveReloadTest.put(address, content).then(null, function(){
+			QUnit.ok(false, "Reload was not successful");
+			QUnit.start();
+		});
+	});
+
+	F("#other").missing("other module was torn down");
+	F("#orphan").exists("But the orphan module still exists");
+});
+
 QUnit.module("retries");
 
 QUnit.asyncTest("something", function(){


### PR DESCRIPTION
An orphan is only an orphan if it only has 1 dependant module (the
    module to which it is no longer a dependency).
