### PR TITLE
Dispose the proper orphan modules

### DIFF
--- a/live.js
+++ b/live.js
@@ -192,8 +192,8 @@ function reload(moduleName) {
 		});
 	}
 
-	for(var moduleName in moduleNames) {
-		imports.push(importModule(moduleName));
+	for(var modName in moduleNames) {
+		imports.push(importModule(modName));
 	}
 	// Once everything is imported call the global listener callback functions.
 	Promise.all(imports).then(function(){

--- a/test/dispose/child.js
+++ b/test/dispose/child.js
@@ -1,0 +1,2 @@
+require('./other');
+require('./third');

--- a/test/dispose/index.html
+++ b/test/dispose/index.html
@@ -1,0 +1,15 @@
+<head><meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+<meta http-equiv="Pragma" content="no-cache" />
+<meta http-equiv="Expires" content="0" /></head>
+<body>
+<script>
+	steal = {
+		configDependencies: ["live-reload"],
+		paths: {
+			"live-reload": "live.js"
+		}
+	};
+</script>
+<script src="../../node_modules/steal/steal.js" main="test/dispose/parent"></script>
+<div id="app"></div>
+</body>

--- a/test/dispose/other.js
+++ b/test/dispose/other.js
@@ -1,0 +1,10 @@
+var reload = require("live-reload");
+var $ = require("jquery");
+
+reload.dispose(function(){
+	$("#app").append("<span id='disposed'>I was disposed when i shouldn't have been</span>");
+});
+
+reload(function(){
+	$("#app").append("<span id='done'>Reload is complete!</span>");
+});

--- a/test/dispose/parent.js
+++ b/test/dispose/parent.js
@@ -1,0 +1,2 @@
+require("./child");
+require("./third");

--- a/test/dispose/third.js
+++ b/test/dispose/third.js
@@ -1,0 +1,6 @@
+var reload = require("live-reload");
+var $ = require("jquery");
+
+reload(function(){
+	$("#app").append("<span id='done'>Reload is complete!</span>");
+});

--- a/test/test.js
+++ b/test/test.js
@@ -114,6 +114,36 @@ QUnit.test("are not orphans if they have another parent", function(){
 
 QUnit.module("retries");
 
-QUnit.asyncTest("something", function(){
+QUnit.asyncTest("work", function(){
 	makeIframe("retry/index.html");
+});
+
+QUnit.module("disposing modules", {
+	setup: function(assert){
+		var done = assert.async();
+		F.open("//dispose/index.html", function(){
+			done();
+		});
+	},
+	teardown: function(assert){
+		var done = assert.async();
+		liveReloadTest.reset().then(function(){
+			done();
+		});
+	}
+});
+
+QUnit.test("the correct modules are disposed", function(){
+	F(function(){
+		var address = "test/dispose/child.js";
+		var content = "requ" + "ire('./other');\nrequ" + "ire('./third');\nvar foo;";
+
+		liveReloadTest.put(address, content).then(null, function(){
+			QUnit.ok(false, "Reload was not successful");
+			QUnit.start();
+		});
+	});
+
+	F("#done").exists("Reloading completed");
+	F("#disposed").missing("The 'other' module wasn't disposed");
 });


### PR DESCRIPTION
When disposing orphans, make sure we are checking against the proper
moduleName. We were re-using the variable `moduleName` in a for loop
which caused the other moduleName to be changed, and as a result we were
disposing of some modules that we should not have been. This adds a test
and a fix.

Fixes #21
