### PR TITLE
Allow live-reload to accept an array of modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
-node_js: 0.12
+node_js: 5.8
 script: npm test
+addons:
+  firefox: "44.0"
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Reload your application as you develop",
   "main": "live.js",
   "scripts": {
-    "test": "live-reload-test & testee test/test.html --browsers firefox --reporter Spec",
+    "test": "live-reload-test & testee test/test.html test/unit.html --browsers firefox --reporter Spec",
     "live-reload-test": "live-reload-test"
   },
   "repository": {
@@ -28,12 +28,13 @@
     "funcunit": "^3.0.0",
     "grunt": "^0.4.5",
     "jquery": "^2.1.4",
-    "live-reload-testing": "^3.0.1",
-    "steal": "^0.12.0-pre.0",
+    "live-reload-testing": "^4.0.0",
+    "steal": "^0.16.0",
     "steal-qunit": "^0.1.1",
     "testee": "^0.2.0"
   },
   "system": {
+	"npmAlgorithm": "flat",
     "npmIgnore": [
       "testee",
       "grunt"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "funcunit": "^3.0.0",
     "grunt": "^0.4.5",
     "jquery": "^2.1.4",
-    "live-reload-testing": "^4.0.0",
+    "live-reload-testing": "^5.0.0",
     "steal": "^0.16.0",
     "steal-qunit": "^0.1.1",
     "testee": "^0.2.0"

--- a/test/teardown/child.js
+++ b/test/teardown/child.js
@@ -1,1 +1,2 @@
 var foo;
+var bar;

--- a/test/unit.html
+++ b/test/unit.html
@@ -1,0 +1,9 @@
+<title>live-reload unit tests</title>
+<script>
+	steal = {
+		map: {
+			"live-reload": "./live"
+		}
+	};
+</script>
+<script src="../node_modules/steal/steal.js" main="test/unit"></script>

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,0 +1,53 @@
+var QUnit = require("steal-qunit");
+var reload = require("live-reload");
+var loader = require("@loader");
+
+QUnit.module("Unit tests", {
+	setup: function(){
+		var fetch = this.oldFetch = loader.fetch;
+		loader.fetch = function(load){
+			if(load.name === "foo") {
+				return Promise.resolve("exports.foo = 'bar'");
+			} else if(load.name === "bar") {
+				return Promise.resolve("exports.bar = 'bam'");
+			}
+		};
+	},
+	teardown: function(){
+		loader.fetch = this.oldFetch;
+	}
+});
+
+QUnit.test("Exports a function", function(assert){
+	assert.equal(typeof reload, "function", "reload is a function");
+});
+
+QUnit.test("Can take a moduleName to teardown", function(assert){
+	var done = assert.async();
+
+	loader.set("foo", loader.newModule({default: {foo:'hah'}}));
+	assert.equal(loader.get("foo").default.foo, 'hah', "initial value is right");
+
+	reload("foo")
+	.then(function(){
+		assert.equal(loader.get("foo").default.foo, 'bar', "value has updated");
+	})
+	.then(done, done);
+});
+
+QUnit.test("Can take an array of moduleNames to teardown", function(assert){
+	var done = assert.async();
+
+	loader.set("foo", loader.newModule({default: {foo:'hah'}}));
+	assert.equal(loader.get("foo").default.foo, 'hah', "initial value is right");
+
+	loader.set("bar", loader.newModule({default: {bar: 'qux'}}));
+	assert.equal(loader.get("bar").default.bar, "qux", "bar is right");
+
+	reload(["foo", "bar"])
+	.then(function(){
+		assert.equal(loader.get("foo").default.foo, 'bar', "value has updated");
+		assert.equal(loader.get("bar").default.bar, "bam", "bar value has updated");
+	})
+	.then(done, done);
+});


### PR DESCRIPTION
Make it so a live-reload server can send an array of modules that need
to be torn down. cycleComplete should still only file after all are torn
down.
